### PR TITLE
27: JUnit 5. Discovery fixes and datamodel dependencies

### DIFF
--- a/securebanking-common-bom/pom.xml
+++ b/securebanking-common-bom/pom.xml
@@ -62,6 +62,15 @@
                 <version>${openbanking-uk-datamodel.version}</version>
             </dependency>
 
+            <!-- Test dependencies -->
+            <dependency>
+                <groupId>com.forgerock.securebanking</groupId>
+                <artifactId>securebanking-common-openbanking-uk-datamodel</artifactId>
+                <version>${openbanking-uk-datamodel.version}</version>
+                <type>test-jar</type>
+                <scope>test</scope>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/securebanking-common-openbanking-uk-datamodel/README.md
+++ b/securebanking-common-openbanking-uk-datamodel/README.md
@@ -28,33 +28,6 @@ In your pom file you should use the `securebanking-common-bom` import (see the R
 
 ```
 
-## Class generation
-Many of the classes are generated from OB Swagger documentation. When a new version of OB API is released, 
-the following steps are performed:
-1. Download the Swagger json files from OB Spec pages (e.g. for 3.1.1 accounts: https://openbanking.atlassian.net/wiki/spaces/DZ/pages/999622968/Account+and+Transaction+API+Specification+-+v3.1.1#AccountandTransactionAPISpecification-v3.1.1-SwaggerSpecification)
->Note: there are currently swagger files for Accounts, Payments, Funds Confirmation, ASPSP Callback and TPP Events - more may be available in future releases).
-1. Download `swagger-codegen-cli-2.4.5.jar`
-1. Run ```
-java -jar swagger-codegen-cli-2.4.5.jar generate \
-    -i {your_json_file} \
-    -DuseBeanValidation=true \
-    -Dmodels \
-    --model-package uk.org.openbanking.datamodel \
-    --group-id com.forgerock.openbanking \
-    --artifact-id openbanking-sdk \
-    -l java \
-    --library resttemplate \
-    -o generated```
- 1. Check the generated files and copy them into appropriate source directory. Do not overwrite existing files.
- 1. Remove Links, Meta, OBError1 and OBErrorResponse1 - we use shared generic versions of these classes.
- 1. Repeat generation for each new swagger json file
- 1. If using Intelij, run format and optimise imports on newly generated files. 
- 1. Increment the major or minor version in pom.xml
- 1. Run build to ensure everything compiles and copyrights are generated for new source files.
- 1. Commit and raise PR.  
-
-
-
 ### How to Build
 
 This is a Java Maven project. 
@@ -72,6 +45,28 @@ git checkout git@github.com:SecureBankingAcceleratorToolkit/securebanking-common
 cd securebanking-common/securebanking-common-openbanking-uk-datamodel
 mvn clean install
 ```
+
+## Class generation
+Many of the classes are generated from the OB Swagger documentation. The project is set-up to make it easy to generate
+the  OB model classes and skeleton API classes using Maven. For efficiency, the default maven profile does not generate
+the code, but it is easy to do so using `code-gen` profile (see below).
+
+The configuration for the swagger generation is currently within `securebanking-openbanking-aspsp-mock/pom.xml` 
+and the swagger specification is within `securebanking-openbanking-aspsp-mock/src/main/resources/specification`.
+
+When a new version of OB API is released, the following steps should be performed:
+ 1. Download the Swagger json files from OB Spec pages (https://github.com/OpenBankingUK/read-write-api-specs)
+    > Note: there are currently swagger files for Accounts, Payments, Funds Confirmation, Callback and TPP Events
+ 1. Run ```mvn clean install -Pcode-gen```
+    > This will generate classes into `securebanking-openbanking-aspsp-mock/target/generated-sources/swagger`
+ 1. Check the generated files and copy them into the appropriate source folder (e.g. `src/main/java`), but **DO NOT**
+ overwrite existing classes.
+ 1. Remove Links, Meta, OBError1 and OBErrorResponse1 - we use shared generic versions of these classes.
+ 1. Uncomment the relevant `<inputSpec>` listing within the `openapi-generator-maven-plugin` in the pom for the next
+ swagger spec (and repeat for each new swagger json file).
+ 1. If using Intellij, run format and optimise imports on newly generated files.
+ 1. Run build to ensure everything compiles and copyrights are generated for new source files.
+ 1. Commit and raise PR.
 
 ## Contributing
 

--- a/securebanking-common-openbanking-uk-datamodel/pom.xml
+++ b/securebanking-common-openbanking-uk-datamodel/pom.xml
@@ -45,13 +45,37 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+        </dependency>
+        <dependency>
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
+        </dependency>
+
+        <!-- Jackson -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-joda</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>joda-time</groupId>
+            <artifactId>joda-time</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger2</artifactId>
@@ -60,6 +84,7 @@
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
         </dependency>
+
         <!-- Bean Validation API support -->
         <dependency>
             <groupId>javax.validation</groupId>
@@ -67,16 +92,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>joda-time</groupId>
-            <artifactId>joda-time</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.annotation</groupId>
             <artifactId>javax.annotation-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
@@ -90,6 +107,19 @@
             <groupId>org.glassfish</groupId>
             <artifactId>javax.el</artifactId>
         </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/securebanking-common-openbanking-uk-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/GenericOBDiscoveryAPILinks.java
+++ b/securebanking-common-openbanking-uk-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/GenericOBDiscoveryAPILinks.java
@@ -1,0 +1,54 @@
+/**
+ * Copyright © 2020 ForgeRock AS (obst@forgerock.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.org.openbanking.datamodel.discovery;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a list of supported Open Banking API endpoints across all of the API "groups" (e.g. PISP, AISP etc.).
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GenericOBDiscoveryAPILinks implements OBDiscoveryAPILinks {
+    private Map<String, String> links = new HashMap<>();
+
+    public GenericOBDiscoveryAPILinks addLink(String reference, String endpoint) {
+        links.put(reference, endpoint);
+        return this;
+    }
+
+    public GenericOBDiscoveryAPILinks addAllLinks(Map<String, String> newLinks) {
+        if (newLinks == null) {
+            return this;
+        }
+        links.putAll(newLinks);
+        return this;
+    }
+
+    public Collection<String> getLinkValues() {
+        return new ArrayList<>(links.values());
+    };
+}

--- a/securebanking-common-openbanking-uk-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
+++ b/securebanking-common-openbanking-uk-datamodel/src/main/java/uk/org/openbanking/datamodel/discovery/OBDiscoveryAPILinks.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 package uk.org.openbanking.datamodel.discovery;
+
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import io.swagger.annotations.ApiModel;
@@ -27,9 +28,9 @@ import io.swagger.annotations.ApiModel;
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksAccount3.class, name = "OBDiscoveryAPILinksAccount3"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksPayment1.class, name = "OBDiscoveryAPILinksPayment1"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksPayment3.class, name = "OBDiscoveryAPILinksPayment3"),
-        @JsonSubTypes.Type(value = OBDiscoveryAPILinksPayment3.class, name = "OBDiscoveryAPILinksPayment4"),
+        @JsonSubTypes.Type(value = OBDiscoveryAPILinksPayment4.class, name = "OBDiscoveryAPILinksPayment4"),
         @JsonSubTypes.Type(value = OBDiscoveryAPILinksFundsConfirmation3.class, name = "OBDiscoveryAPILinksFundsConfirmation3"),
-        @JsonSubTypes.Type(value = OBDiscoveryAPILinksEventNotification3.class, name = "OBDiscoveryAPILinksEventNotification3"),
+        @JsonSubTypes.Type(value = GenericOBDiscoveryAPILinks.class, name = "GenericOBDiscoveryAPILinks")
 })
 @ApiModel(description = "Endpoints corresponding to a specific version")
 public interface OBDiscoveryAPILinks {

--- a/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverterTest.java
+++ b/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/datamodel/service/converter/OBExternalAccountIdentificationConverterTest.java
@@ -15,67 +15,63 @@
  */
 package uk.org.openbanking.datamodel.service.converter;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification3Code;
 import uk.org.openbanking.datamodel.account.OBExternalAccountIdentification4Code;
 import uk.org.openbanking.datamodel.payment.OBExternalAccountIdentification2Code;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static uk.org.openbanking.datamodel.service.converter.account.OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification3;
 import static uk.org.openbanking.datamodel.service.converter.account.OBExternalAccountIdentificationConverter.toOBExternalAccountIdentification4;
 
+/**
+ * Unit test for {@link uk.org.openbanking.datamodel.service.converter.account.OBExternalAccountIdentificationConverter}.
+ */
 public class OBExternalAccountIdentificationConverterTest {
 
     @Test
     public void toOBExternalAccountIdentification3_fromOBExternalAccountIdentification4Code() {
-        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER),
-                is(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER));
+        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER))
+                .isEqualTo(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER);
 
-        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.IBAN),
-                is(OBExternalAccountIdentification3Code.IBAN));
+        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.IBAN))
+                .isEqualTo(OBExternalAccountIdentification3Code.IBAN);
 
+        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.PAN))
+                .isEqualTo(OBExternalAccountIdentification3Code.PAN);
 
-        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.PAN),
-                is(OBExternalAccountIdentification3Code.PAN));
+        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.BBAN)).isNull();
 
-        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.BBAN),
-                nullValue());
-
-        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.PAYM),
-                nullValue());
+        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification4Code.PAYM)).isNull();
     }
 
     @Test
     public void toOBExternalAccountIdentification3_fromOBExternalAccountIdentification2Code() {
-        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification2Code.SortCodeAccountNumber),
-                is(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER));
+        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification2Code.SortCodeAccountNumber))
+                .isEqualTo(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER);
 
-        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification2Code.IBAN),
-                is(OBExternalAccountIdentification3Code.IBAN));
+        assertThat(toOBExternalAccountIdentification3(OBExternalAccountIdentification2Code.IBAN))
+                .isEqualTo(OBExternalAccountIdentification3Code.IBAN);
     }
 
     @Test
     public void toOBExternalAccountIdentification4_fromOBExternalAccountIdentification2Code() {
-        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification2Code.SortCodeAccountNumber),
-                is(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER));
+        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification2Code.SortCodeAccountNumber))
+                .isEqualTo(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER);
 
-        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification2Code.IBAN),
-                is(OBExternalAccountIdentification4Code.IBAN));
-
+        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification2Code.IBAN))
+                .isEqualTo(OBExternalAccountIdentification4Code.IBAN);
     }
 
     @Test
     public void toOBExternalAccountIdentification4_fromOBExternalAccountIdentification3Code() {
-        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER),
-                is(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER));
+        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.SORTCODEACCOUNTNUMBER))
+                .isEqualTo(OBExternalAccountIdentification4Code.SORTCODEACCOUNTNUMBER);
 
-        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.IBAN),
-                is(OBExternalAccountIdentification4Code.IBAN));
+        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.IBAN))
+                .isEqualTo(OBExternalAccountIdentification4Code.IBAN);
 
-
-        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.PAN),
-                is(OBExternalAccountIdentification4Code.PAN));
+        assertThat(toOBExternalAccountIdentification4(OBExternalAccountIdentification3Code.PAN))
+                .isEqualTo(OBExternalAccountIdentification4Code.PAN);
     }
 }

--- a/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBRiskSerializerTest.java
+++ b/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBRiskSerializerTest.java
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 package uk.org.openbanking.jackson.account;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.org.openbanking.datamodel.account.OBRisk2;
 
 import java.io.IOException;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Unit test for {@link uk.org.openbanking.jackson.account.OBRisk2Serializer}.
+ */
 public class OBRiskSerializerTest {
 
     private ObjectMapper mapper = new ObjectMapper();
@@ -38,7 +41,6 @@ public class OBRiskSerializerTest {
         String resultValue = mapper.writeValueAsString(obRisk2);
 
         //Then
-        assertThat(expectedValue, is(resultValue));
-
+        assertThat(expectedValue).isEqualTo(resultValue);
     }
 }

--- a/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBSupplementarySerializerTest.java
+++ b/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/jackson/account/OBSupplementarySerializerTest.java
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 package uk.org.openbanking.jackson.account;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import uk.org.openbanking.datamodel.payment.OBSupplementaryData1;
 
 import java.io.IOException;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * Unit test for {@link uk.org.openbanking.jackson.account.OBSupplementaryData1Serializer}.
+ */
 public class OBSupplementarySerializerTest {
 
     private ObjectMapper mapper = new ObjectMapper();
@@ -38,7 +41,7 @@ public class OBSupplementarySerializerTest {
         String resultValue = mapper.writeValueAsString(obSupplementaryData1);
 
         //Then
-        assertThat(expectedValue, is(resultValue));
+        assertThat(expectedValue).isEqualTo(resultValue);
 
     }
 }

--- a/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
+++ b/securebanking-common-openbanking-uk-datamodel/src/test/java/uk/org/openbanking/validation/CurrencyCodeValidatorTest.java
@@ -14,29 +14,32 @@
  * limitations under the License.
  */
 package uk.org.openbanking.validation;
-import org.junit.Test;
 
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.assertThat;
+import org.junit.jupiter.api.Test;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit test for {@link CurrencyCodeValidator}.
+ */
 public class CurrencyCodeValidatorTest {
 
     private final CurrencyCodeValidator currencyCodeValidator = new CurrencyCodeValidator();
 
     @Test
     public void isValid() {
-        assertThat(currencyCodeValidator.isValid("GBP", null), is(true));
-        assertThat(currencyCodeValidator.isValid("EUR", null), is(true));
-        assertThat(currencyCodeValidator.isValid("USD", null), is(true));
-        assertThat(currencyCodeValidator.isValid("TRY", null), is(true));
-        assertThat(currencyCodeValidator.isValid("XTS", null), is(true));
+        assertThat(currencyCodeValidator.isValid("GBP", null)).isTrue();
+        assertThat(currencyCodeValidator.isValid("EUR", null)).isTrue();
+        assertThat(currencyCodeValidator.isValid("USD", null)).isTrue();
+        assertThat(currencyCodeValidator.isValid("TRY", null)).isTrue();
+        assertThat(currencyCodeValidator.isValid("XTS", null)).isTrue();
 
-        assertThat(currencyCodeValidator.isValid("", null), is(false));
-        assertThat(currencyCodeValidator.isValid(null, null), is(false));
-        assertThat(currencyCodeValidator.isValid("A", null), is(false));
-        assertThat(currencyCodeValidator.isValid("AB", null), is(false));
-        assertThat(currencyCodeValidator.isValid("NCC", null), is(false));
-        assertThat(currencyCodeValidator.isValid("ABCD", null), is(false));
-        assertThat(currencyCodeValidator.isValid("1234", null), is(false));
+        assertThat(currencyCodeValidator.isValid("", null)).isFalse();
+        assertThat(currencyCodeValidator.isValid(null, null)).isFalse();
+        assertThat(currencyCodeValidator.isValid("A", null)).isFalse();
+        assertThat(currencyCodeValidator.isValid("AB", null)).isFalse();
+        assertThat(currencyCodeValidator.isValid("NCC", null)).isFalse();
+        assertThat(currencyCodeValidator.isValid("ABCD", null)).isFalse();
+        assertThat(currencyCodeValidator.isValid("1234", null)).isFalse();
     }
 }


### PR DESCRIPTION
This PR introduces these changes:

 - Migrates unit tests to JUnit 5
 - Adds Lombok and Guava dependencies
 - Adds required changes for Discovery endpoint
 - Adds generation of test-jar for test data factories
 - Fixed jackson/joda dependencies for the datamodel module

Issue: https://github.com/SecureBankingAcceleratorToolkit/SecureBankingAcceleratorToolkit/issues/27